### PR TITLE
Update Makefile to use '3DS' in short description instead of 'new 3DS'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ GFXBUILD	:=	$(ROMFS)/gfx
 #---------------------------------------------------------------------------------
 APP_VER					:= 82
 APP_TITLE				:= ThirdTube
-APP_DESCRIPTION				:= A YouTube client for the new 3DS
+APP_DESCRIPTION				:= A YouTube client for the 3DS
 APP_AUTHOR				:= windows_server_2003
 PRODUCT_CODE				:= CTR-TYT
 UNIQUE_ID				:= 0xBF74D


### PR DESCRIPTION
An update to the short description which changes the short description from "A YouTube client for the new 3DS" to "A YouTube client for the 3DS", because the Homebrew application is now compatible with both old and new 3DS models.