### PR TITLE
Fix Node.js 16 Unsupported Warning (Update to Node.js 20)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,11 +13,11 @@ jobs:
     container: devkitpro/devkitarm
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: make
       run: make
     - name: Upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Build
         path: |


### PR DESCRIPTION
I made some changes to the workflow so every action that's being ran uses V4, which utilizes Node.js 20 instead of 16. Because 16 is now unsupported (but still included to the GitHub runners for some time) it's better that we use Node.js 20 for the GitHub actions.